### PR TITLE
条件のkeyを取得するエンドポイントを実装

### DIFF
--- a/app/controllers/api/v1/flows_controller.rb
+++ b/app/controllers/api/v1/flows_controller.rb
@@ -39,6 +39,16 @@ module Api
         end
       end
 
+      # GET /api/v1/flows/condition_keys
+      def condition_keys
+        begin
+          keys = Shinsei.column_names
+          render json: {keys: keys}, status: :ok
+        rescue => e
+          render json: { error: e.message }, status: :internal_server_error
+        end
+      end
+
       private
 
       # shape of the params: list of condition and list of approvers

--- a/app/controllers/api/v1/flows_controller.rb
+++ b/app/controllers/api/v1/flows_controller.rb
@@ -43,7 +43,7 @@ module Api
       def condition_keys
         begin
           keys = Shinsei.column_names
-          render json: {keys: keys}, status: :ok
+          render json: {key: keys}, status: :ok
         rescue => e
           render json: { error: e.message }, status: :internal_server_error
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
       # /flows
       post 'flows', to: 'flows#create'
       get 'flows', to: 'flows#index'
+      get 'flows/condition_keys', to: 'flows#condition_keys'
       get 'flows/:id', to: 'flows#show'
 
       # /approvals

--- a/front/openapi/openapi.yml
+++ b/front/openapi/openapi.yml
@@ -380,6 +380,28 @@ paths:
                 properties:
                   message:
                     type: string
+  /flows/condition_keys:
+    get:
+      summary: Get candidate of keys in conditions for flow
+      tags:
+        - Flows
+      operationId: getConditions
+      responses:
+        '200':
+          description: Conditions retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Keys'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
   /approvals:
     post:
       summary: Create a new approval
@@ -589,3 +611,11 @@ components:
         status:
           description: 承認状態（approved, pending, rejected）
           type: string
+    Keys:
+      description: 条件のキー
+      type: object
+      properties:
+        key:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
## 修正・追加した内容
GET `/api/v1/flows/condition_keys` で申請フローにおけるconditionのkeyの候補を取得できるように
## レビューしてほしいポイント
openapiの定義通りに動くか
## その他
